### PR TITLE
level-up styling now working on mobile

### DIFF
--- a/gymbrohero/components/LevelUp.jsx
+++ b/gymbrohero/components/LevelUp.jsx
@@ -1,54 +1,56 @@
-import React, { useState } from 'react';
 import { View, Text, Image, StyleSheet, Pressable } from 'react-native';
 
 export const LevelUp = (props) => {
+  const closeWindow = () => {
+    props.setClosedLevelUp(true);
+  };
 
-        const closeWindow = () => {
-            props.setClosedLevelUp(true)
-        }
-
-    return (<View style={styles.container}>
-        <View style={styles.box}>
-        <Image source={require('../images/Bro.png')} style={styles.image} resizeMode="cover"></Image>
+  return (
+    <View style={styles.container}>
+      <View style={styles.box}>
+        <View style={styles.button}>
+          <Pressable onPress={closeWindow}>
+            <Text>x</Text>
+          </Pressable>
+        </View>
+        <Image
+          source={require('../images/Bro.png')}
+          style={styles.image}
+          resizeMode="cover"
+        ></Image>
         <Text style={styles.text}>You Levelled up bro!</Text>
         <Text style={styles.text}>New Items unlocked in store</Text>
-        {/* <Text style={styles.text}>{props.closedLevelUp ? 'true' : 'false'}</Text> */}
-        <View style= {styles.button}>
-        <Pressable onPress={closeWindow}>
-        <Text >x</Text>
-        </Pressable>
-        </View>
-        </View>
-    </View>)
-}
+      </View>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
-	container: {
-		// flex: 1,
-        alignItems: 'center',
-	},
-    box: {
-        borderRadius: 20,
-		alignItems: 'center',
-		padding: 20,
-        backgroundColor: 'grey',
-        margin: 30,
-        marginTop: 100
-	},
-	image: {
-		width: 200,
-		height: 200
-	},
-	text: {
-		marginTop: 20,
-		fontSize: 18
-	},
-    button: {
-        position: 'absolute', 
-        padding: 10,
-        top: 0,
-        right: 0,
-        width: 30,
-        height: 10,
-	}
+  container: {
+    alignItems: 'center',
+  },
+  box: {
+    borderRadius: 20,
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: 'white',
+    margin: 30,
+    marginTop: 100,
+  },
+  image: {
+    width: 200,
+    height: 200,
+  },
+  text: {
+    marginTop: 20,
+    fontSize: 18,
+  },
+  button: {
+    position: 'absolute',
+    padding: 15,
+    top: 0,
+    right: 0,
+    backgroundColor: 'grey',
+    borderRadius: 10,
+  },
 });

--- a/gymbrohero/screens/HomeScreen.jsx
+++ b/gymbrohero/screens/HomeScreen.jsx
@@ -12,3 +12,4 @@ export default function HomeScreen() {
         </View>
     )
 }
+


### PR DESCRIPTION
level-up styling now working on mobile, fixed positioning errors with close button, so now work on expo go. flex box had to be removed, will see if this causes downstream issues. 